### PR TITLE
added quiet alignment validation mode

### DIFF
--- a/axml.h
+++ b/axml.h
@@ -1111,6 +1111,7 @@ typedef  struct {
   boolean       optimizeBaseFrequencies;
   boolean       ascertainmentBias;
   boolean       rellBootstrap;
+  boolean       quietAlignmentValidation;
 } analdef;
 
 


### PR DESCRIPTION
Added a command line option (-$, but could be anything) to enable silencing the individual alignment validation messages (duplicate sequences, entirely undetermined columns) and instead reporting a single summary message. This saves a lot of print operations on long, gappy alignments and for my use case (lots of replicate topology searches on long gappy alignments) saves a lot of time.
