### PR TITLE
use more portabel perl shebangs

### DIFF
--- a/usefulScripts/ProteinModelSelection.pl
+++ b/usefulScripts/ProteinModelSelection.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 #print $ARGV[0]." ".$ARGV[1]." ".$#ARGV."\n";
 

--- a/usefulScripts/applyRAxML2AllFilesInDirectory.pl
+++ b/usefulScripts/applyRAxML2AllFilesInDirectory.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 #print $ARGV[0]." ".$ARGV[1]." ".$#ARGV."\n";
 

--- a/usefulScripts/bsBranchLengths.pl
+++ b/usefulScripts/bsBranchLengths.pl
@@ -1,4 +1,4 @@
-#!/usr/local/bin/perl
+#!/usr/bin/env perl
 
 print $ARGV[0]." ".$ARGV[1]." ".$ARGV[2]." ".$#ARGV."\n";
 


### PR DESCRIPTION
use `/usr/bin/env perl` instead of `/usr/local/bin/perl` as it finds
perl in non-hard-coded locations
