### PR TITLE
fix parenthesis mismatch bug leads to potential unexpected behavior

### DIFF
--- a/axml.c
+++ b/axml.c
@@ -8331,7 +8331,7 @@ static void finalizeInfoFile(tree *tr, analdef *adef)
 			default:
 			  assert(0);
 			}
-		    break;
+		    } break;
 		  case GENERIC_64:
 		    assert(0);
 		    break;
@@ -8424,7 +8424,6 @@ static void finalizeInfoFile(tree *tr, analdef *adef)
 		    default:
 		      assert(0);
 		    }
-		  }
 		
 		if(adef->useInvariant)
 		  params += 2;


### PR DESCRIPTION
Reverted the code cleanup/reformatting due to merge conflicts and only fixed both
places.

Finding this issue was not easy because of the bad code formatting.
The Microsoft compiler throw errors either about not initialized
variables or not reachable code.

Unfortunately the gcc and clang based build have had no problems with
this malformed parenthesis but I’m unsure if they just optimize away the
non reachable code.

will close #29

Remark: most file need a white-space tidy up and correct re-formatting
to be easier to read (especially in stacked switch/case blocks with
stack frames).