### PR TITLE
Remove #include <malloc.h>

### DIFF
--- a/mem_alloc.c
+++ b/mem_alloc.c
@@ -7,9 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#if !defined(__APPLE__)
-#include <malloc.h>
-#endif
 
 
 #ifdef _RAXML_USE_LLALLOC

--- a/mem_alloc.c
+++ b/mem_alloc.c
@@ -7,6 +7,9 @@
 #include <stdlib.h>
 #include <string.h>
 
+#ifdef WIN32
+#include <malloc.h>
+#endif
 
 
 #ifdef _RAXML_USE_LLALLOC


### PR DESCRIPTION
malloc.h is currently conditionally included for non-macOS platforms in mem_alloc.c. This results in a compile-time error on FreeBSD 10.3:

```
$ make -f Makefile.SSE3.PTHREADS.gcc
...
In file included from mem_alloc.c:11:0:
/usr/include/malloc.h:3:2: error: #error "<malloc.h> has been replaced by <stdlib.h>"
 #error "<malloc.h> has been replaced by <stdlib.h>"
  ^
*** Error code 1
```

As the malloc() family of functions referenced in mem_alloc.c are declared per the C standard in stdlib.h (which also declares posix_memalign() on POSIX systems), it shouldn't be necessary to explicitly include malloc.h.

I've tested this patch on both FreeBSD 10.3 with gcc 4.9.4, and Ubuntu 12.04 LTS with gcc 4.6.3.  