### PR TITLE
Add Linux ARM64 for the Makefile.SSE3.** configs

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,63 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  build:
+    name: Build on Linux x86_64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        intrinsics: ["", ".SSE3", ".AVX", ".AVX2"]
+        type: ["", ".PTHREADS", ".MPI", ".HYBRID", ".QuartetMPI"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y file openmpi-bin libopenmpi-dev
+
+    - name: Build
+      run: |
+        set -x
+        if [[ -f Makefile${{ matrix.intrinsics }}${{ matrix.type }}.gcc ]]; then
+          make -j -f Makefile${{ matrix.intrinsics }}${{ matrix.type }}.gcc all
+          file raxmlHPC* | grep x86-64
+        fi
+
+  build-aarch64:
+    name: Build on Linux aarch64
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        intrinsics: ["", ".SSE3"]
+        type: ["", ".PTHREADS", ".MPI", ".HYBRID", ".QuartetMPI"]
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Build
+      uses: uraimo/run-on-arch-action@v2
+      with:
+        arch: aarch64
+        distro: ubuntu20.04
+        githubToken: ${{ github.token }}
+        dockerRunArgs: |
+          --volume "${PWD}:/raxml"
+        install: |
+          apt-get update -q -y
+          apt-get install -q -y make gcc file openmpi-bin libopenmpi-dev
+        run: |
+          set -x
+          make -j -f Makefile${{ matrix.intrinsics }}${{ matrix.type }}.gcc all
+          file raxmlHPC* | grep aarch64

--- a/Makefile.SSE3.HYBRID.gcc
+++ b/Makefile.SSE3.HYBRID.gcc
@@ -2,7 +2,14 @@
 
 CC = mpicc 
 
-CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+ARCH_CFLAGS=-msse3
+else ifeq ($(ARCH), aarch64)
+ARCH_CFLAGS=
+endif
+
+CFLAGS = -D_WAYNE_MPI -D_USE_PTHREADS -D__SIM_SSE3 -O2 -D_GNU_SOURCE $(ARCH_CFLAGS) -fomit-frame-pointer -funroll-loops  
 
 LIBRARIES = -lm -pthread 
 

--- a/Makefile.SSE3.MPI.gcc
+++ b/Makefile.SSE3.MPI.gcc
@@ -2,7 +2,14 @@
 
 CC = mpicc 
 
-CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE -msse3 -fomit-frame-pointer -funroll-loops  
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+ARCH_CFLAGS=-msse3
+else ifeq ($(ARCH), aarch64)
+ARCH_CFLAGS=
+endif
+
+CFLAGS = -D_WAYNE_MPI -D__SIM_SSE3 -O2 -D_GNU_SOURCE $(ARCH_CFLAGS) -fomit-frame-pointer -funroll-loops  
 
 LIBRARIES = -lm
 

--- a/Makefile.SSE3.PTHREADS.gcc
+++ b/Makefile.SSE3.PTHREADS.gcc
@@ -3,7 +3,14 @@
 
 CC = gcc 
 
-CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE -msse3 -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+ARCH_CFLAGS=-msse3
+else ifeq ($(ARCH), aarch64)
+ARCH_CFLAGS=
+endif
+
+CFLAGS = -D_USE_PTHREADS -D__SIM_SSE3 -D_GNU_SOURCE $(ARCH_CFLAGS) -O2 -fomit-frame-pointer -funroll-loops  #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
 
 
 LIBRARIES = -lm -pthread 

--- a/Makefile.SSE3.QuartetMPI.gcc
+++ b/Makefile.SSE3.QuartetMPI.gcc
@@ -3,7 +3,14 @@
 
 CC = mpicc
 
-CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+ARCH_CFLAGS=-msse3
+else ifeq ($(ARCH), aarch64)
+ARCH_CFLAGS=
+endif
+
+CFLAGS = -D__SIM_SSE3 $(ARCH_CFLAGS) -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  -D_QUARTET_MPI #-Wall -pedantic -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes  -Wdeclaration-after-statement -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
 
 LIBRARIES = -lm
 

--- a/Makefile.SSE3.gcc
+++ b/Makefile.SSE3.gcc
@@ -3,7 +3,14 @@
 
 CC = gcc 
 
-CFLAGS = -D__SIM_SSE3  -msse3 -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-pedantic -Wall  -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
+ARCH := $(shell uname -m)
+ifeq ($(ARCH), x86_64)
+ARCH_CFLAGS=-msse3
+else ifeq ($(ARCH), aarch64)
+ARCH_CFLAGS=
+endif
+
+CFLAGS = -D__SIM_SSE3 $(ARCH_CFLAGS) -D_GNU_SOURCE -O2 -fomit-frame-pointer -funroll-loops  #-pedantic -Wall  -Wunused-parameter -Wredundant-decls  -Wreturn-type  -Wswitch-default -Wunused-value -Wimplicit  -Wimplicit-function-declaration  -Wimplicit-int -Wimport  -Wunused  -Wunused-function  -Wunused-label -Wno-int-to-pointer-cast -Wbad-function-cast  -Wmissing-declarations -Wmissing-prototypes  -Wnested-externs  -Wold-style-definition -Wstrict-prototypes -Wpointer-sign -Wextra -Wredundant-decls -Wunused -Wunused-function -Wunused-parameter -Wunused-value  -Wunused-variable -Wformat  -Wformat-nonliteral -Wparentheses -Wsequence-point -Wuninitialized -Wundef -Wbad-function-cast
 
 LIBRARIES = -lm
 

--- a/bipartitionList.c
+++ b/bipartitionList.c
@@ -46,10 +46,12 @@
 #include "rmq.h" //include range minimum queries for fast plausibility checker
 
 #ifdef __SIM_SSE3
-
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
-
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
 #endif
 
 #ifdef _USE_PTHREADS

--- a/evaluateGenericSpecial.c
+++ b/evaluateGenericSpecial.c
@@ -39,11 +39,14 @@
 #include <string.h>
 #include "axml.h"
 
-
 #ifdef __SIM_SSE3
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
 /*#include <tmmintrin.h>*/
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
 #endif
 
 #ifdef _USE_PTHREADS

--- a/evaluatePartialGenericSpecial.c
+++ b/evaluatePartialGenericSpecial.c
@@ -41,10 +41,13 @@
 #include "axml.h"
 
 #ifdef __SIM_SSE3
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
+#elif __aarch64__
+#include "sse2neon.h"
 #endif
-
+#endif
 
 /********************** GTRCAT ***************************************/
 

--- a/fastDNAparsimony.c
+++ b/fastDNAparsimony.c
@@ -61,9 +61,13 @@
 
 #ifdef __SIM_SSE3
 
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
-  
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
+
 #endif
 
 #ifdef __AVX

--- a/makenewzGenericSpecial.c
+++ b/makenewzGenericSpecial.c
@@ -44,9 +44,13 @@
 #include "axml.h"
 
 #ifdef __SIM_SSE3
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
 /*#include <tmmintrin.h>*/
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
 #endif
 
 #ifdef _USE_PTHREADS

--- a/newviewGenericSpecial.c
+++ b/newviewGenericSpecial.c
@@ -44,8 +44,13 @@
 #ifdef __SIM_SSE3
 
 #include <stdint.h>
+
+#ifdef __x86_64__
 #include <xmmintrin.h>
 #include <pmmintrin.h>
+#elif __aarch64__
+#include "sse2neon.h"
+#endif
 
 const union __attribute__ ((aligned (BYTE_ALIGNMENT)))
 {


### PR DESCRIPTION
Use sse2neon.h when building any SSE based Makefile on Linux ARM64.

Add CI based on Github Actions that runs:
- all Makefiles (including the AVX ones) on Linux x86_64
- all Makefiles but the AVX ones on Linux aarch64
The CI will be enabled once this PR is merged to `master` branch. You can see a successful run on my fork - https://github.com/martin-g/standard-RAxML/actions/runs/6376539163